### PR TITLE
Qt5.11.2 clang osx sizeof build error

### DIFF
--- a/qge/AbilityCell.h
+++ b/qge/AbilityCell.h
@@ -6,6 +6,7 @@
 
 #include "Gui.h"
 #include "Ability.h"
+#include "Panel.h"
 
 class QGraphicsItem;
 class QGraphicsPixmapItem;

--- a/qge/Bar.h
+++ b/qge/Bar.h
@@ -3,6 +3,7 @@
 #include <QObject>
 #include <QColor>
 #include <QPixmap>
+#include <QGraphicsPixmapItem>
 #include <memory>
 
 #include "Gui.h"

--- a/qge/DialogGui.h
+++ b/qge/DialogGui.h
@@ -5,6 +5,7 @@
 #include <memory>
 
 #include "Gui.h"
+#include "ScrollWindow.h"
 #include <QObject>
 
 class QGraphicsItem;

--- a/qge/DialogGui.h
+++ b/qge/DialogGui.h
@@ -3,10 +3,10 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <memory>
+#include <QObject>
 
 #include "Gui.h"
 #include "ScrollWindow.h"
-#include <QObject>
 
 class QGraphicsItem;
 

--- a/qge/Entity.h
+++ b/qge/Entity.h
@@ -11,6 +11,7 @@
 #include <memory>
 
 #include "PathingMap.h"
+#include "AsyncShortestPathFinder.h"
 
 class QPointF;
 class QTimer;

--- a/qge/InventoryUser.h
+++ b/qge/InventoryUser.h
@@ -4,6 +4,7 @@
 #include <QObject>
 
 #include "Gui.h"
+#include "InventoryViewer.h"
 
 class QGraphicsItem;
 

--- a/qge/InventoryViewer.h
+++ b/qge/InventoryViewer.h
@@ -8,6 +8,7 @@
 
 #include "Gui.h"
 #include "Inventory.h"
+#include "ScrollWindow.h"
 
 class QPointF;
 

--- a/qge/ItemCell.h
+++ b/qge/ItemCell.h
@@ -6,6 +6,7 @@
 
 #include "Item.h"
 #include "Gui.h"
+#include "Panel.h"
 
 class QGraphicsItem;
 class QGraphicsPixmapItem;

--- a/qge/ItemCell.h
+++ b/qge/ItemCell.h
@@ -3,6 +3,7 @@
 #include <QPointer>
 #include <memory>
 #include <QObject>
+#include <QGraphicsPixmapItem>
 
 #include "Item.h"
 #include "Gui.h"

--- a/qge/Map.h
+++ b/qge/Map.h
@@ -7,6 +7,7 @@
 #include "PathingMap.h"
 #include "Game.h"
 #include "PositionalSound.h"
+#include "TerrainLayer.h"
 
 class QPolygonF;
 class QGraphicsItem;

--- a/qge/PathingMap.h
+++ b/qge/PathingMap.h
@@ -88,6 +88,6 @@ private:
     int cellSize_;
 };
 
-Q_DECLARE_METATYPE(PathingMap);
-
 }
+
+Q_DECLARE_METATYPE(qge::PathingMap);

--- a/qge/PositionalSound.h
+++ b/qge/PositionalSound.h
@@ -5,6 +5,8 @@
 #include <memory>
 #include <QObject>
 
+#include "Sound.h"
+
 namespace qge{
 
 class Map;


### PR DESCRIPTION
While trying to build on OSX with Clang and -std=c++14 I got a number of build errors.  I wasn't able to push to your repo so I forked the project in order to commit the changes.

You should see a number of headers that required forwarded classes to be imported.

With these changes the test application builds and runs on OSX Mohave.