### PR TITLE
[Optimization] add precompiled headers

### DIFF
--- a/qge/Ability.cpp
+++ b/qge/Ability.cpp
@@ -1,5 +1,4 @@
 #include "Ability.h"
-#include <cassert>
 
 using namespace qge;
 

--- a/qge/Ability.h
+++ b/qge/Ability.h
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <QPointer>
-#include <string>
+#include "Vendor.h"
 
 #include "Entity.h"
 #include "Sprite.h"

--- a/qge/AbilityCell.cpp
+++ b/qge/AbilityCell.cpp
@@ -1,7 +1,5 @@
 #include "AbilityCell.h"
 
-#include <QGraphicsPixmapItem>
-
 #include "Panel.h"
 #include "Ability.h"
 #include "Sprite.h"

--- a/qge/AbilityCell.h
+++ b/qge/AbilityCell.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include <QPointer>
-#include <memory>
-#include <QObject>
+#include "Vendor.h"
 
 #include "Gui.h"
 #include "Ability.h"

--- a/qge/AngledSprite.cpp
+++ b/qge/AngledSprite.cpp
@@ -1,7 +1,5 @@
 #include "AngledSprite.h"
 
-#include <cassert>
-
 #include "Sprite.h"
 #include "Utilities.h"
 #include "STLWrappers.h"

--- a/qge/AngledSprite.h
+++ b/qge/AngledSprite.h
@@ -1,9 +1,6 @@
 #pragma once
 
-#include <string>
-#include <vector>
-#include <unordered_set>
-#include <unordered_map>
+#include "Vendor.h"
 
 #include "EntitySprite.h"
 

--- a/qge/Animation.cpp
+++ b/qge/Animation.cpp
@@ -1,8 +1,5 @@
 #include "Animation.h"
 
-#include <QTimer>
-#include <stdexcept>
-
 #include "SpriteSheet.h"
 #include "Utilities.h"
 #include "Node.h"

--- a/qge/Animation.h
+++ b/qge/Animation.h
@@ -1,9 +1,6 @@
 #pragma once
 
-#include <vector>
-#include <QSizeF>
-#include <QObject>
-#include <QGraphicsItem>
+#include "Vendor.h"
 
 class QTimer;
 class QPixmap;

--- a/qge/AnimationAttack.cpp
+++ b/qge/AnimationAttack.cpp
@@ -1,8 +1,5 @@
 #include "AnimationAttack.h"
 
-#include <cassert>
-#include <QDebug>
-
 #include "PositionalSound.h"
 #include "Slot.h"
 #include "EntitySprite.h"

--- a/qge/AnimationAttack.h
+++ b/qge/AnimationAttack.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <string>
+#include "Vendor.h"
 
 #include "MeleeWeapon.h"
 

--- a/qge/AsyncShortestPathFinder.cpp
+++ b/qge/AsyncShortestPathFinder.cpp
@@ -1,7 +1,5 @@
 #include "AsyncShortestPathFinder.h"
 
-#include <QDebug>
-
 using namespace qge;
 
 /// Calculates a Path from a starting point to an ending point in the specified

--- a/qge/AsyncShortestPathFinder.h
+++ b/qge/AsyncShortestPathFinder.h
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <QObject>
-#include <QThread>
+#include "Vendor.h"
 
 #include "PathingMap.h"
 

--- a/qge/Axe.cpp
+++ b/qge/Axe.cpp
@@ -1,8 +1,5 @@
 #include "Axe.h"
 
-#include <QGraphicsScene>
-#include <QDebug> // TODO: remove
-
 #include "Sprite.h"
 #include "Map.h"
 #include "Inventory.h"

--- a/qge/Axe.h
+++ b/qge/Axe.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "Vendor.h"
+
 #include "MeleeWeapon.h"
 
 class QTimer;

--- a/qge/Bar.cpp
+++ b/qge/Bar.cpp
@@ -1,7 +1,5 @@
 #include "Bar.h"
 
-#include <QGraphicsPixmapItem>
-
 using namespace qge;
 
 Bar::Bar():

--- a/qge/Bar.h
+++ b/qge/Bar.h
@@ -1,10 +1,6 @@
 #pragma once
 
-#include <QObject>
-#include <QColor>
-#include <QPixmap>
-#include <QGraphicsPixmapItem>
-#include <memory>
+#include "Vendor.h"
 
 #include "Gui.h"
 

--- a/qge/BodyThrust.cpp
+++ b/qge/BodyThrust.cpp
@@ -1,9 +1,5 @@
 #include "BodyThrust.h"
 
-#include <QGraphicsScene>
-#include <QDebug> // TODO: remove
-#include <cassert>
-
 #include "Sprite.h"
 #include "Map.h"
 #include "Inventory.h"

--- a/qge/BodyThrust.h
+++ b/qge/BodyThrust.h
@@ -1,10 +1,8 @@
 #pragma once
 
+#include "Vendor.h"
+
 #include "NoTargetAbility.h"
-
-#include <QObject>
-#include <QPointF>
-
 #include "PlayingAnimationInfo.h"
 
 class QTimer;

--- a/qge/Bow.cpp
+++ b/qge/Bow.cpp
@@ -6,7 +6,6 @@
 #include "Sprite.h"
 #include "Entity.h"
 #include "Sound.h"
-#include <cassert>
 #include "CBDamage.h"
 #include "TopDownSprite.h"
 

--- a/qge/Bow.h
+++ b/qge/Bow.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "Vendor.h"
+
 #include "RangedWeapon.h"
 
 class QPointF;

--- a/qge/Button.cpp
+++ b/qge/Button.cpp
@@ -1,10 +1,5 @@
 #include "Button.h"
 
-#include <QGraphicsRectItem>
-#include <QGraphicsTextItem>
-#include <QBrush>
-#include <QFont>
-
 using namespace qge;
 
 Button::Button():

--- a/qge/Button.h
+++ b/qge/Button.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include <string>
-#include <QGraphicsPixmapItem>
-#include <QColor>
+#include "Vendor.h"
 
 #include "Gui.h"
 

--- a/qge/CBDamage.h
+++ b/qge/CBDamage.h
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <unordered_set>
-#include <utility>
+#include "Vendor.h"
 
 #include "CollisionBehavior.h"
 #include "Entity.h"

--- a/qge/CHealthShower.cpp
+++ b/qge/CHealthShower.cpp
@@ -1,8 +1,5 @@
 #include "CHealthShower.h"
 
-#include <QTimer>
-#include <cassert>
-
 #include "STLWrappers.h"
 #include "Entity.h"
 #include "Map.h"

--- a/qge/CHealthShower.h
+++ b/qge/CHealthShower.h
@@ -1,9 +1,6 @@
 #pragma once
 
-#include <QObject>
-#include <unordered_set>
-#include <unordered_map>
-#include <QPoint>
+#include "Vendor.h"
 
 class QTimer;
 

--- a/qge/CItemDropper.h
+++ b/qge/CItemDropper.h
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <QObject>
-#include <unordered_set>
+#include "Vendor.h"
 
 namespace qge{
 

--- a/qge/CollisionBehavior.h
+++ b/qge/CollisionBehavior.h
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <set>
-#include <string>
+#include "Vendor.h"
 
 namespace qge{
 

--- a/qge/CountExpiringTimer.cpp
+++ b/qge/CountExpiringTimer.cpp
@@ -1,7 +1,5 @@
 #include "CountExpiringTimer.h"
 
-#include <cassert>
-
 using namespace qge;
 
 CountExpiringTimer::CountExpiringTimer(QObject *parent):

--- a/qge/CountExpiringTimer.h
+++ b/qge/CountExpiringTimer.h
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <QObject>
-#include <QTimer>
+#include "Vendor.h"
 
 namespace qge{
 

--- a/qge/DialogGui.cpp
+++ b/qge/DialogGui.cpp
@@ -1,7 +1,5 @@
 #include "DialogGui.h"
 
-#include <cassert>
-
 #include "Label.h"
 #include "ScrollWindow.h"
 

--- a/qge/DialogGui.h
+++ b/qge/DialogGui.h
@@ -1,9 +1,6 @@
 #pragma once
 
-#include <unordered_map>
-#include <unordered_set>
-#include <memory>
-#include <QObject>
+#include "Vendor.h"
 
 #include "Gui.h"
 #include "ScrollWindow.h"

--- a/qge/DiplomacyManager.h
+++ b/qge/DiplomacyManager.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <unordered_map>
+#include "Vendor.h"
 
 namespace qge{
 

--- a/qge/ECBodyThruster.cpp
+++ b/qge/ECBodyThruster.cpp
@@ -1,8 +1,5 @@
 #include "ECBodyThruster.h"
 
-#include <cassert>
-#include <QTimer>
-
 #include "ECChaser.h"
 #include "BodyThrust.h"
 #include "QtUtilities.h"

--- a/qge/ECBodyThruster.h
+++ b/qge/ECBodyThruster.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include <QPointer>
-#include <QObject>
-#include <memory>
+#include "Vendor.h"
 
 #include "EntityController.h"
 #include "Entity.h"

--- a/qge/ECCameraFollower.cpp
+++ b/qge/ECCameraFollower.cpp
@@ -1,7 +1,5 @@
 #include "ECCameraFollower.h"
 
-#include <cassert>
-
 #include "Map.h"
 #include "Game.h"
 

--- a/qge/ECCameraFollower.h
+++ b/qge/ECCameraFollower.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include <QObject>
-#include <QPointer>
-#include <QPointF>
+#include "Vendor.h"
 
 #include "EntityController.h"
 #include "Entity.h"

--- a/qge/ECChaser.cpp
+++ b/qge/ECChaser.cpp
@@ -1,9 +1,5 @@
 #include "ECChaser.h"
 
-#include <cassert>
-#include <QTimer>
-#include <QDebug> // TODO: test remove
-
 #include "ECFieldOfViewEmitter.h"
 #include "ECPathMover.h"
 #include "Map.h"

--- a/qge/ECChaser.h
+++ b/qge/ECChaser.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include <QPointer>
-#include <unordered_set>
-#include <memory>
+#include "Vendor.h"
 
 #include "EntityController.h"
 #include "Entity.h"

--- a/qge/ECCurrentMapGrabber.cpp
+++ b/qge/ECCurrentMapGrabber.cpp
@@ -1,7 +1,5 @@
 #include "ECCurrentMapGrabber.h"
 
-#include <cassert>
-
 #include "Map.h"
 #include "Game.h"
 

--- a/qge/ECCurrentMapGrabber.h
+++ b/qge/ECCurrentMapGrabber.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <QPointer>
+#include "Vendor.h"
 
 #include "EntityController.h"
 #include "Entity.h"

--- a/qge/ECEnemyAttacker.cpp
+++ b/qge/ECEnemyAttacker.cpp
@@ -1,7 +1,5 @@
 #include "ECEnemyAttacker.h"
 
-#include <cassert>
-
 #include "ECChaser.h"
 #include "Slot.h"
 #include "Weapon.h"

--- a/qge/ECEnemyAttacker.h
+++ b/qge/ECEnemyAttacker.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include <QPointer>
-#include <QObject>
-#include <memory>
+#include "Vendor.h"
 
 #include "Entity.h"
 #include "EntityController.h"

--- a/qge/ECFieldOfViewEmitter.cpp
+++ b/qge/ECFieldOfViewEmitter.cpp
@@ -1,13 +1,5 @@
 #include "ECFieldOfViewEmitter.h"
 
-#include <cassert>
-#include <QObject>
-#include <QTimer>
-#include <QLineF>
-#include <QPointF>
-#include <QPolygonF>
-#include <QDebug>
-
 #include "Entity.h"
 #include "Map.h"
 

--- a/qge/ECFieldOfViewEmitter.h
+++ b/qge/ECFieldOfViewEmitter.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include <unordered_set>
-#include <QPointer>
-#include <QGraphicsPolygonItem>
+#include "Vendor.h"
 
 #include "EntityController.h"
 #include "Entity.h"

--- a/qge/ECGuiShower.h
+++ b/qge/ECGuiShower.h
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <unordered_set>
-#include <QPointer>
+#include "Vendor.h"
 
 #include "EntityController.h"
 

--- a/qge/ECItemPickerUpper.cpp
+++ b/qge/ECItemPickerUpper.cpp
@@ -1,7 +1,5 @@
 #include "ECItemPickerUpper.h"
 
-#include <cassert>
-
 #include "Inventory.h"
 #include "Item.h"
 

--- a/qge/ECItemPickerUpper.h
+++ b/qge/ECItemPickerUpper.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <QPointer>
+#include "Vendor.h"
 
 #include "EntityController.h"
 #include "Entity.h"

--- a/qge/ECKeyboardMover4Directional.cpp
+++ b/qge/ECKeyboardMover4Directional.cpp
@@ -1,8 +1,5 @@
 #include "ECKeyboardMover4Directional.h"
 
-#include <QTimer>
-#include <cassert>
-
 #include "Map.h"
 #include "Game.h"
 #include "Sprite.h"

--- a/qge/ECKeyboardMover4Directional.h
+++ b/qge/ECKeyboardMover4Directional.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <QPointer>
+#include "Vendor.h"
 
 #include "EntityController.h"
 #include "Entity.h"

--- a/qge/ECKeyboardMover8Directional.cpp
+++ b/qge/ECKeyboardMover8Directional.cpp
@@ -1,8 +1,5 @@
 #include "ECKeyboardMover8Directional.h"
 
-#include <QTimer>
-#include <cassert>
-
 #include "Map.h"
 #include "Game.h"
 #include "Sprite.h"

--- a/qge/ECKeyboardMover8Directional.h
+++ b/qge/ECKeyboardMover8Directional.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <QPointer>
+#include "Vendor.h"
 
 #include "EntityController.h"
 #include "Entity.h"

--- a/qge/ECKeyboardMoverPerspective.cpp
+++ b/qge/ECKeyboardMoverPerspective.cpp
@@ -1,7 +1,5 @@
 #include "ECKeyboardMoverPerspective.h"
 
-#include <cassert>
-
 #include "Map.h"
 #include "QTimer"
 #include "Utilities.h"

--- a/qge/ECKeyboardMoverPerspective.h
+++ b/qge/ECKeyboardMoverPerspective.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <QPointer>
+#include "Vendor.h"
 
 #include "EntityController.h"
 #include "Entity.h"

--- a/qge/ECMapMover.cpp
+++ b/qge/ECMapMover.cpp
@@ -1,7 +1,5 @@
 #include "ECMapMover.h"
 
-#include <cassert>
-
 #include "Map.h"
 #include "Game.h"
 #include "MapGrid.h"

--- a/qge/ECMapMover.h
+++ b/qge/ECMapMover.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <QPointer>
+#include "Vendor.h"
 
 #include "EntityController.h"
 #include "Entity.h"

--- a/qge/ECMouseFacer.cpp
+++ b/qge/ECMouseFacer.cpp
@@ -1,8 +1,5 @@
 #include "ECMouseFacer.h"
 
-#include <cassert>
-#include <QTimer>
-
 #include "ECRotater.h"
 #include "Map.h"
 

--- a/qge/ECMouseFacer.h
+++ b/qge/ECMouseFacer.h
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <QPointer>
-#include <memory>
+#include "Vendor.h"
 
 #include "EntityController.h"
 #include "Entity.h"

--- a/qge/ECMover.cpp
+++ b/qge/ECMover.cpp
@@ -1,7 +1,5 @@
 #include "ECMover.h"
 
-#include <cassert>
-
 using namespace qge;
 
 /// Constructs a Mover that can move the specified Entity.

--- a/qge/ECMover.h
+++ b/qge/ECMover.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <QPointer>
+#include "Vendor.h"
 
 #include "EntityController.h"
 #include "Entity.h"

--- a/qge/ECPathMover.cpp
+++ b/qge/ECPathMover.cpp
@@ -1,9 +1,5 @@
 #include "ECPathMover.h"
 
-#include <QTimer>
-#include <cassert>
-#include <QLineF>
-
 #include "AsyncShortestPathFinder.h"
 #include "Sprite.h"
 #include "Map.h"

--- a/qge/ECPathMover.h
+++ b/qge/ECPathMover.h
@@ -1,10 +1,6 @@
 #pragma once
 
-#include <QPointer>
-#include <QPointF>
-#include <vector>
-#include <QPointF>
-#include <memory>
+#include "Vendor.h"
 
 #include "Entity.h"
 #include "ECMover.h"

--- a/qge/ECRotater.cpp
+++ b/qge/ECRotater.cpp
@@ -1,9 +1,5 @@
 #include "ECRotater.h"
 
-#include <cassert>
-#include <QTimer>
-#include <QLineF>
-
 #include "Entity.h"
 #include "Sprite.h"
 #include "Utilities.h"

--- a/qge/ECRotater.h
+++ b/qge/ECRotater.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include <QObject>
-#include <QPointF>
-#include <QPointer>
+#include "Vendor.h"
 
 #include "EntityController.h"
 #include "Entity.h"

--- a/qge/ECSineMover.cpp
+++ b/qge/ECSineMover.cpp
@@ -1,9 +1,5 @@
 #include "ECSineMover.h"
 
-#include <QTimer>
-#include <cassert>
-#include <QtMath>
-
 #include "Utilities.h"
 
 using namespace qge;

--- a/qge/ECSineMover.h
+++ b/qge/ECSineMover.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include <QObject>
-#include <QPointer>
-#include <QLineF>
+#include "Vendor.h"
 
 #include "Entity.h"
 #include "ECMover.h"

--- a/qge/ECStraightMover.cpp
+++ b/qge/ECStraightMover.cpp
@@ -1,9 +1,5 @@
 #include "ECStraightMover.h"
 
-#include <QTimer>
-#include <cassert>
-#include <QLineF>
-
 #include "Utilities.h"
 #include "QtUtilities.h"
 

--- a/qge/ECStraightMover.h
+++ b/qge/ECStraightMover.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include <QPointer>
-#include <QObject>
-#include <QPointF>
+#include "Vendor.h"
 
 #include "Entity.h"
 #include "ECMover.h"

--- a/qge/Edge.cpp
+++ b/qge/Edge.cpp
@@ -1,7 +1,5 @@
 #include "Edge.h"
 
-#include <cassert>
-
 using namespace qge;
 
 /// Do not use, just so Edge can be in a map.

--- a/qge/Edge.h
+++ b/qge/Edge.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "Vendor.h"
+
 #include "Node.h"    
 
 namespace qge{

--- a/qge/Entity.cpp
+++ b/qge/Entity.cpp
@@ -1,11 +1,5 @@
 #include "Entity.h"
 
-#include <string>
-#include <cassert>
-#include <QGraphicsScene>
-#include <QLineF>
-#include <algorithm>
-
 #include "Map.h"
 #include "EntitySprite.h"
 #include "TopDownSprite.h"

--- a/qge/Entity.h
+++ b/qge/Entity.h
@@ -1,12 +1,6 @@
 #pragma once
 
-#include <unordered_map>
-#include <unordered_set>
-#include <string>
-#include <set>
-#include <QPointer>
-#include <utility>
-#include <memory>
+#include "Vendor.h"
 
 #include "PathingMap.h"
 #include "AsyncShortestPathFinder.h"

--- a/qge/EntityController.h
+++ b/qge/EntityController.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <QObject>
+#include "Vendor.h"
 
 #include "Entity.h"
 

--- a/qge/EntitySprite.cpp
+++ b/qge/EntitySprite.cpp
@@ -1,9 +1,5 @@
 #include "EntitySprite.h"
 
-#include <QRectF>
-#include <QGraphicsItem>
-#include <cassert>
-
 using namespace qge;
 
 EntitySprite::EntitySprite(): underlyingItem_(nullptr)

--- a/qge/EntitySprite.h
+++ b/qge/EntitySprite.h
@@ -1,9 +1,6 @@
 #pragma once
 
-#include <QObject>
-#include <string>
-#include <QSize>
-#include <QPointF>
+#include "Vendor.h"
 
 #include "PlayingAnimationInfo.h"
 

--- a/qge/EntityTargetItem.cpp
+++ b/qge/EntityTargetItem.cpp
@@ -1,7 +1,5 @@
 #include "EntityTargetItem.h"
 
-#include <cassert>
-
 #include "EntityTargetAbility.h"
 #include "TopDownSprite.h"
 

--- a/qge/EntityTargetItem.h
+++ b/qge/EntityTargetItem.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "Vendor.h"
+
 #include "Item.h"
 
 namespace qge{

--- a/qge/EquipableItem.cpp
+++ b/qge/EquipableItem.cpp
@@ -1,8 +1,5 @@
 #include "EquipableItem.h"
 
-#include <QPointF>
-#include <cassert>
-
 #include "Inventory.h"
 #include "Slot.h"
 #include "Entity.h"

--- a/qge/EquipableItem.h
+++ b/qge/EquipableItem.h
@@ -1,7 +1,8 @@
 #pragma once
 
+#include "Vendor.h"
+
 #include "Item.h"
-#include <QPixmap>
 
 class QPointF;
 

--- a/qge/FireballLauncher.cpp
+++ b/qge/FireballLauncher.cpp
@@ -4,7 +4,6 @@
 #include "SpearProjectile.h"
 #include "Sound.h"
 #include "Inventory.h"
-#include "cassert"
 #include "Map.h"
 #include "CBDamage.h"
 

--- a/qge/FireballLauncher.h
+++ b/qge/FireballLauncher.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "Vendor.h"
+
 #include "RangedWeapon.h"
 
 class QPointF;

--- a/qge/FogWeather.cpp
+++ b/qge/FogWeather.cpp
@@ -1,12 +1,5 @@
 #include "FogWeather.h"
 
-#include <QTimer>
-#include <QGraphicsScene>
-#include <QGraphicsPixmapItem>
-#include <cassert>
-#include <QRectF>
-#include <QDebug>
-
 #include "Utilities.h"
 #include "Map.h"
 #include "Game.h"

--- a/qge/FogWeather.h
+++ b/qge/FogWeather.h
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <QObject>
-#include <set>
+#include "Vendor.h"
 
 #include "WeatherEffect.h"
 #include "QVector2D"

--- a/qge/Game.cpp
+++ b/qge/Game.cpp
@@ -1,11 +1,5 @@
 #include "Game.h"
 
-#include <cstdlib>
-#include <QMouseEvent>
-#include <ctime>
-#include <cassert>
-#include <QGraphicsItem>
-
 #include "Map.h"
 #include "Spear.h" // TODO remove, test
 #include "Entity.h"

--- a/qge/Game.h
+++ b/qge/Game.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include <QGraphicsView>
-#include <set>
-#include <unordered_set>
+#include "Vendor.h"
 
 #include "DiplomacyManager.h"
 

--- a/qge/Graph.cpp
+++ b/qge/Graph.cpp
@@ -1,9 +1,5 @@
 #include "Graph.h"
 
-#include <vector>
-#include <cassert>
-#include <algorithm>
-
 #include "Tree.h"
 
 using namespace qge;

--- a/qge/Graph.h
+++ b/qge/Graph.h
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <unordered_set>
-#include <unordered_map>
+#include "Vendor.h"
 
 #include "Node.h"
 #include "Edge.h"

--- a/qge/Grid.cpp
+++ b/qge/Grid.cpp
@@ -1,9 +1,5 @@
 #include "Grid.h"
 
-#include <QPointF>
-#include <cassert>
-#include <QRectF>
-
 #include "Node.h"
 
 using namespace qge;

--- a/qge/Grid.h
+++ b/qge/Grid.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <vector>
+#include "Vendor.h"
 
 class QPointF;
 class QRectF;

--- a/qge/Gui.cpp
+++ b/qge/Gui.cpp
@@ -1,7 +1,5 @@
 #include "Gui.h"
 
-#include <QGraphicsItem>
-
 #include "Game.h"
 
 using namespace qge;

--- a/qge/Gui.h
+++ b/qge/Gui.h
@@ -1,9 +1,6 @@
 #pragma once
 
-#include <QObject>
-#include <QPointF>
-#include <unordered_set>
-#include <QPointer>
+#include "Vendor.h"
 
 class QGraphicsItem;
 class QGraphicsItem;

--- a/qge/Inventory.cpp
+++ b/qge/Inventory.cpp
@@ -1,8 +1,5 @@
 #include "Inventory.h"
 
-#include <cassert>
-#include <typeindex>
-
 #include "EquipableItem.h"
 #include "NoTargetItem.h"
 #include "EntityTargetItem.h"

--- a/qge/Inventory.h
+++ b/qge/Inventory.h
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <unordered_set>
-#include <QObject>
+#include "Vendor.h"
 
 namespace qge{
 

--- a/qge/InventoryUser.cpp
+++ b/qge/InventoryUser.cpp
@@ -1,7 +1,5 @@
 #include "InventoryUser.h"
 
-#include <cassert>
-
 #include "InventoryViewer.h"
 #include "Game.h"
 #include "EquipableItem.h"

--- a/qge/InventoryUser.h
+++ b/qge/InventoryUser.h
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <memory>
-#include <QObject>
+#include "Vendor.h"
 
 #include "Gui.h"
 #include "InventoryViewer.h"

--- a/qge/InventoryViewer.cpp
+++ b/qge/InventoryViewer.cpp
@@ -1,12 +1,3 @@
-#include <QGraphicsRectItem>
-
-#include <QBrush>
-#include <QtMath>
-#include <unordered_set>
-#include <iterator>
-#include <QPointF>
-#include <QGraphicsScene>
-
 #include "InventoryViewer.h"
 #include "Inventory.h"
 #include "ItemCell.h"

--- a/qge/InventoryViewer.h
+++ b/qge/InventoryViewer.h
@@ -1,10 +1,6 @@
 #pragma once
 
-#include <QPixmap>
-#include <QColor>
-#include <memory>
-#include <QPointer>
-#include <QObject>
+#include "Vendor.h"
 
 #include "Gui.h"
 #include "Inventory.h"

--- a/qge/Item.cpp
+++ b/qge/Item.cpp
@@ -1,7 +1,5 @@
 #include "Item.h"
 
-#include <cassert>
-
 #include "Inventory.h"
 #include "Sprite.h"
 

--- a/qge/Item.h
+++ b/qge/Item.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include <vector>
-#include <string>
-#include <QPixmap>
+#include "Vendor.h"
 
 #include "Entity.h"
 

--- a/qge/ItemCell.cpp
+++ b/qge/ItemCell.cpp
@@ -1,12 +1,5 @@
 #include "ItemCell.h"
 
-#include <cassert>
-#include <QPixmap>
-#include <QImage>
-#include <QGraphicsSceneMouseEvent>
-#include <QGraphicsSimpleTextItem>
-#include <QBrush>
-
 #include "Item.h"
 #include "Inventory.h"
 #include "Panel.h"

--- a/qge/ItemCell.h
+++ b/qge/ItemCell.h
@@ -1,9 +1,6 @@
 #pragma once
 
-#include <QPointer>
-#include <memory>
-#include <QObject>
-#include <QGraphicsPixmapItem>
+#include "Vendor.h"
 
 #include "Item.h"
 #include "Gui.h"

--- a/qge/ItemHealthPotion.cpp
+++ b/qge/ItemHealthPotion.cpp
@@ -1,8 +1,5 @@
 #include "ItemHealthPotion.h"
 
-#include <QPixmap>
-#include <cassert>
-
 #include "Inventory.h"
 #include "Entity.h"
 #include "TopDownSprite.h"

--- a/qge/ItemHealthPotion.h
+++ b/qge/ItemHealthPotion.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "Vendor.h"
+
 #include "NoTargetItem.h"
 
 namespace qge{

--- a/qge/ItemPushback.cpp
+++ b/qge/ItemPushback.cpp
@@ -1,8 +1,5 @@
 #include "ItemPushback.h"
 
-#include <cassert>
-#include <QPixmap>
-
 #include "Entity.h"
 #include "Inventory.h"
 #include "Sprite.h"

--- a/qge/ItemPushback.h
+++ b/qge/ItemPushback.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "Vendor.h"
+
 #include "EntityTargetItem.h"
 
 namespace qge{

--- a/qge/ItemTeleport.cpp
+++ b/qge/ItemTeleport.cpp
@@ -1,7 +1,5 @@
 #include "ItemTeleport.h"
 
-#include <cassert>
-
 #include "Sprite.h"
 #include "Entity.h"
 #include "Inventory.h"

--- a/qge/ItemTeleport.h
+++ b/qge/ItemTeleport.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "Vendor.h"
+
 #include "PointTargetItem.h"
 
 namespace qge{

--- a/qge/Label.cpp
+++ b/qge/Label.cpp
@@ -1,11 +1,5 @@
 #include "Label.h"
 
-#include <QGraphicsTextItem>
-
-#include <QFont>
-#include <QDebug>
-#include <QBrush>
-
 using namespace qge;
 
 Label::Label(const std::string &text):

--- a/qge/Label.h
+++ b/qge/Label.h
@@ -1,9 +1,6 @@
 #pragma once
 
-#include <QObject>
-#include <string>
-#include <QColor>
-#include <QGraphicsItem>
+#include "Vendor.h"
 
 #include "Gui.h"
 

--- a/qge/MCSpawner.cpp
+++ b/qge/MCSpawner.cpp
@@ -1,8 +1,5 @@
 #include "MCSpawner.h"
 
-#include <QTimer>
-#include <cassert>
-
 #include "Entity.h"
 #include "Map.h"
 #include "AngledSprite.h"

--- a/qge/MCSpawner.h
+++ b/qge/MCSpawner.h
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <QObject>
-#include <QRectF>
+#include "Vendor.h"
 
 #include "RandomGenerator.h"
 #include "EntityCreator.h"

--- a/qge/Map.cpp
+++ b/qge/Map.cpp
@@ -1,10 +1,5 @@
 #include "Map.h"
 
-#include <QGraphicsScene>
-#include <cassert>
-#include <QBrush>
-#include <QGraphicsOpacityEffect>
-
 #include "TerrainLayer.h"
 #include "Entity.h"
 #include "Game.h"

--- a/qge/Map.h
+++ b/qge/Map.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include <vector>
-#include <QPointer>
-#include <QObject>
+#include "Vendor.h"
 
 #include "PathingMap.h"
 #include "Game.h"

--- a/qge/MapGrid.cpp
+++ b/qge/MapGrid.cpp
@@ -1,7 +1,5 @@
 #include "MapGrid.h"
 
-#include <cassert>
-
 #include "Node.h"
 
 using namespace qge;

--- a/qge/MapGrid.h
+++ b/qge/MapGrid.h
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <vector>
-#include <QPointer>
+#include "Vendor.h"
 
 #include "Map.h"
 #include "PointerGrid.h"

--- a/qge/MeleeWeapon.cpp
+++ b/qge/MeleeWeapon.cpp
@@ -1,7 +1,5 @@
 #include "MeleeWeapon.h"
 
-#include <cassert>
-
 #include "Sprite.h"
 #include "Map.h"
 #include "EntitySprite.h"

--- a/qge/MeleeWeapon.h
+++ b/qge/MeleeWeapon.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <memory>
+#include "Vendor.h"
 
 #include "Weapon.h"
 #include "CollisionBehavior.h"

--- a/qge/NoTargetAbility.cpp
+++ b/qge/NoTargetAbility.cpp
@@ -1,5 +1,5 @@
 #include "NoTargetAbility.h"
-#include <cassert>
+
 #include "Entity.h"
 
 using namespace qge;

--- a/qge/NoTargetAbility.h
+++ b/qge/NoTargetAbility.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "Vendor.h"
+
 #include "Ability.h"
 
 namespace qge{

--- a/qge/Node.h
+++ b/qge/Node.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <vector>
+#include "Vendor.h"
 
 namespace qge{
 

--- a/qge/Panel.cpp
+++ b/qge/Panel.cpp
@@ -1,11 +1,5 @@
 #include "Panel.h"
 
-#include <QGraphicsPixmapItem>
-#include <QBrush>
-#include <QGraphicsRectItem>
-#include <QPen>
-#include <QGraphicsSceneMouseEvent>
-
 #include "QtUtilities.h"
 
 using namespace qge;

--- a/qge/Panel.h
+++ b/qge/Panel.h
@@ -1,11 +1,6 @@
 #pragma once
 
-#include <QColor>
-#include <QPixmap>
-#include <QObject>
-#include <QGraphicsPixmapItem>
-#include <QGraphicsRectItem>
-#include <memory>
+#include "Vendor.h"
 
 #include "Gui.h"
 

--- a/qge/PathGrid.cpp
+++ b/qge/PathGrid.cpp
@@ -1,8 +1,5 @@
 #include "PathGrid.h"
 
-#include <cassert>
-#include <QDebug>
-
 #include "Tree.h"
 
 using namespace qge;

--- a/qge/PathGrid.h
+++ b/qge/PathGrid.h
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <vector>
-#include <unordered_map>
+#include "Vendor.h"
 
 #include "Node.h"
 #include "Graph.h"

--- a/qge/PathingMap.cpp
+++ b/qge/PathingMap.cpp
@@ -1,10 +1,5 @@
 #include "PathingMap.h"
 
-#include <cassert>
-#include <QDebug> // TODO: remove
-#include <QImage>
-#include <QPixmap>
-
 #include "Grid.h"
 
 using namespace qge;

--- a/qge/PathingMap.h
+++ b/qge/PathingMap.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include <QPointF>
-#include <QRectF>
-#include <QMetaType>
+#include "Vendor.h"
 
 #include "PathGrid.h"
 

--- a/qge/PlayingAnimationInfo.cpp
+++ b/qge/PlayingAnimationInfo.cpp
@@ -1,7 +1,5 @@
 #include "PlayingAnimationInfo.h"
 
-#include <cassert>
-
 using namespace qge;
 
 /// Constructs a PlayingAnimationInfo that reprsents no animation playing.

--- a/qge/PlayingAnimationInfo.h
+++ b/qge/PlayingAnimationInfo.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <string>
+#include "Vendor.h"
 
 namespace qge{
 

--- a/qge/PointerGrid.h
+++ b/qge/PointerGrid.h
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <vector>
-#include <cassert>
+#include "Vendor.h"
 
 #include "Node.h"
 

--- a/qge/PositionalSound.cpp
+++ b/qge/PositionalSound.cpp
@@ -1,7 +1,5 @@
 #include "PositionalSound.h"
 
-#include <cassert>
-
 #include "Sound.h"
 #include "Map.h"
 #include "Game.h"

--- a/qge/PositionalSound.h
+++ b/qge/PositionalSound.h
@@ -1,9 +1,6 @@
 #pragma once
 
-#include <QPointF>
-#include <string>
-#include <memory>
-#include <QObject>
+#include "Vendor.h"
 
 #include "Sound.h"
 

--- a/qge/Projectile.cpp
+++ b/qge/Projectile.cpp
@@ -1,9 +1,5 @@
 #include "Projectile.h"
 
-#include <QTimer>
-#include <QDebug> // TODO: remove, test
-#include <cassert>
-
 #include "Map.h"
 #include "CollisionBehavior.h"
 #include "STLWrappers.h"

--- a/qge/Projectile.h
+++ b/qge/Projectile.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include <unordered_set>
-#include <QPointer>
-#include <memory>
+#include "Vendor.h"
 
 #include "Entity.h"
 #include "ECMover.h"

--- a/qge/QtUtilities.cpp
+++ b/qge/QtUtilities.cpp
@@ -1,13 +1,5 @@
 #include "QtUtilities.h"
 
-#include <QPixmap>
-#include <QImage>
-#include <QColor>
-#include <QtMath>
-#include <QPoint>
-#include <QRect>
-#include <cassert>
-
 namespace qge{
 
 namespace QtUtils {

--- a/qge/QtUtilities.h
+++ b/qge/QtUtilities.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "Vendor.h"
+
 class QPixmap;
 class QImage;
 class QColor;

--- a/qge/Quest.h
+++ b/qge/Quest.h
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <QObject>
-#include <string>
+#include "Vendor.h"
 
 namespace qge{
 

--- a/qge/QuestAcceptor.h
+++ b/qge/QuestAcceptor.h
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <memory>
-#include <QObject>
+#include "Vendor.h"
 
 #include "Gui.h"
 #include "QuestViewer.h"

--- a/qge/QuestViewer.cpp
+++ b/qge/QuestViewer.cpp
@@ -1,8 +1,5 @@
 #include "QuestViewer.h"
 
-#include <QGraphicsRectItem>
-#include <QDebug>
-
 #include "Quests.h"
 #include "Panel.h"
 #include "Label.h"

--- a/qge/QuestViewer.h
+++ b/qge/QuestViewer.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include <unordered_map>
-#include <memory>
-#include <QObject>
+#include "Vendor.h"
 
 #include "Gui.h"
 #include "Panel.h"

--- a/qge/Quests.cpp
+++ b/qge/Quests.cpp
@@ -1,9 +1,5 @@
 #include "Quests.h"
 
-#include <cassert>
-
-#include "algorithm"
-
 using namespace qge;
 
 Quests::Quests()

--- a/qge/Quests.h
+++ b/qge/Quests.h
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <QObject>
-#include <vector>
+#include "Vendor.h"
 
 #include "Quest.h"
 

--- a/qge/RainOfSpearsAbility.cpp
+++ b/qge/RainOfSpearsAbility.cpp
@@ -1,7 +1,5 @@
 #include "RainOfSpearsAbility.h"
 
-#include <QTimer>
-
 #include "Sprite.h"
 #include "Sound.h"
 #include "SpearProjectile.h"

--- a/qge/RainOfSpearsAbility.h
+++ b/qge/RainOfSpearsAbility.h
@@ -1,7 +1,8 @@
 #pragma once
 
-#include "NoTargetAbility.h"
+#include "Vendor.h"
 
+#include "NoTargetAbility.h"
 
 namespace qge{
 

--- a/qge/RainWeather.cpp
+++ b/qge/RainWeather.cpp
@@ -1,8 +1,5 @@
 #include "RainWeather.h"
 
-#include <QTimer>
-#include <cassert>
-
 #include "Game.h"
 #include "Sprite.h"
 #include "Map.h"

--- a/qge/RainWeather.h
+++ b/qge/RainWeather.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <QObject>
+#include "Vendor.h"
 
 #include "WeatherEffect.h"
 

--- a/qge/RandomGenerator.cpp
+++ b/qge/RandomGenerator.cpp
@@ -1,11 +1,5 @@
 #include "RandomGenerator.h"
 
-#include <ctime> // time()
-#include <cstdlib> // srand() and rand()
-#include <cmath> // fmod (float modulus - in c/c++ '%' is only for integral types)
-#include <QPointF>
-#include <QRectF>
-
 using namespace qge;
 
 RandomGenerator::RandomGenerator()

--- a/qge/RandomGenerator.h
+++ b/qge/RandomGenerator.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "Vendor.h"
+
 class QPointF;
 class QRectF;
 

--- a/qge/RandomImageEntity.h
+++ b/qge/RandomImageEntity.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <vector>
+#include "Vendor.h"
 
 #include "PathingMap.h"
 #include "Entity.h"

--- a/qge/RangedWeaponSlot.cpp
+++ b/qge/RangedWeaponSlot.cpp
@@ -1,8 +1,5 @@
 #include "RangedWeaponSlot.h"
 
-#include <QLineF>
-#include <cassert>
-
 #include "RangedWeapon.h"
 #include "Inventory.h"
 #include "Entity.h"

--- a/qge/RangedWeaponSlot.h
+++ b/qge/RangedWeaponSlot.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "Vendor.h"
+
 #include "Slot.h"
 
 namespace qge{

--- a/qge/STLWrappers.h
+++ b/qge/STLWrappers.h
@@ -12,11 +12,7 @@
 /// All functions use the most efficient search, add, and removal operations available for the container.
 /// @file
 
-#include <algorithm>
-#include <set>
-#include <unordered_set>
-#include <map>
-#include <unordered_map>
+#include "Vendor.h"
 
 /// This namespace contains some STL wrapper functions that provide a simpler interface to the STL.
 /// Read the STLWrappers.h documentation for more info.

--- a/qge/ScrollBar.cpp
+++ b/qge/ScrollBar.cpp
@@ -1,9 +1,5 @@
 #include "ScrollBar.h"
 
-#include <QGraphicsSceneMouseEvent>
-#include <cassert>
-#include <QDebug> // TODO: remove
-
 #include "QtUtilities.h"
 
 using namespace qge;

--- a/qge/ScrollBar.h
+++ b/qge/ScrollBar.h
@@ -1,9 +1,6 @@
 #pragma once
 
-#include <QGraphicsPixmapItem>
-#include <QColor>
-#include <QPixmap>
-#include <QObject>
+#include "Vendor.h"
 
 #include "Gui.h"
 

--- a/qge/ScrollWindow.cpp
+++ b/qge/ScrollWindow.cpp
@@ -1,7 +1,5 @@
 #include "ScrollWindow.h"
 
-#include <cassert>
-
 #include "ScrollBar.h"
 #include "Panel.h"
 

--- a/qge/ScrollWindow.h
+++ b/qge/ScrollWindow.h
@@ -1,12 +1,6 @@
 #pragma once
 
-#include <vector>
-#include <QPointF>
-#include <unordered_map>
-#include <QColor>
-#include <QPixmap>
-#include <memory>
-#include <QObject>
+#include "Vendor.h"
 
 #include "ScrollBar.h"
 #include "Gui.h"

--- a/qge/ShardsOfFireAbility.cpp
+++ b/qge/ShardsOfFireAbility.cpp
@@ -1,7 +1,5 @@
 #include "ShardsOfFireAbility.h"
 
-#include <QLine>
-
 #include "Sound.h"
 #include "SpearProjectile.h"
 #include "Map.h"

--- a/qge/ShardsOfFireAbility.h
+++ b/qge/ShardsOfFireAbility.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "Vendor.h"
+
 #include "NoTargetAbility.h"
 
 namespace qge{

--- a/qge/ShopGui.h
+++ b/qge/ShopGui.h
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <QPointer>
-#include <QObject>
+#include "Vendor.h"
 
 #include "Gui.h"
 #include "InventoryViewer.h"

--- a/qge/Slot.cpp
+++ b/qge/Slot.cpp
@@ -1,7 +1,5 @@
 #include "Slot.h"
 
-#include <cassert>
-
 #include "EquipableItem.h"
 #include "Sprite.h"
 #include "Entity.h"

--- a/qge/Slot.h
+++ b/qge/Slot.h
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <QPointF>
-#include <string>
+#include "Vendor.h"
 
 namespace qge{
 

--- a/qge/SnowWeather.cpp
+++ b/qge/SnowWeather.cpp
@@ -1,11 +1,5 @@
 #include "SnowWeather.h"
 
-#include <QTimer>
-#include <QGraphicsScene>
-#include <QGraphicsPixmapItem>
-#include <cassert>
-#include <QDebug>
-
 #include "Map.h"
 #include "Game.h"
 

--- a/qge/SnowWeather.h
+++ b/qge/SnowWeather.h
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <vector>
-#include <QObject>
+#include "Vendor.h"
 
 #include "WeatherEffect.h"
 

--- a/qge/Sound.cpp
+++ b/qge/Sound.cpp
@@ -1,7 +1,5 @@
 #include "Sound.h"
 
-#include <QDebug> // TODO: remove
-
 using namespace qge;
 
 Sound::Sound(std::string filePath, QObject *parent):

--- a/qge/Sound.h
+++ b/qge/Sound.h
@@ -1,9 +1,6 @@
 #pragma once
 
-#include <string>
-#include <QMediaPlayer>
-#include <QObject>
-#include <QTimer>
+#include "Vendor.h"
 
 namespace qge{
 

--- a/qge/Spear.cpp
+++ b/qge/Spear.cpp
@@ -1,8 +1,5 @@
 #include "Spear.h"
 
-#include <QGraphicsScene>
-#include <QDebug> // TODO: remove
-
 #include "Sprite.h"
 #include "Map.h"
 #include "Inventory.h"

--- a/qge/Spear.h
+++ b/qge/Spear.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <QTimer>
+#include "Vendor.h"
 
 #include "MeleeWeapon.h"
 

--- a/qge/Sprite.cpp
+++ b/qge/Sprite.cpp
@@ -1,10 +1,5 @@
 #include "Sprite.h"
 
-#include <cassert>
-#include <QDebug>
-#include <QGraphicsScene>
-#include <QTimer>
-
 #include "Node.h"
 #include "SpriteSheet.h"
 #include "Utilities.h"

--- a/qge/Sprite.h
+++ b/qge/Sprite.h
@@ -1,11 +1,6 @@
 #pragma once
 
-#include <string>
-#include <QGraphicsItem>
-#include <QObject>
-#include <unordered_map>
-#include <vector>
-#include <QPixmap>
+#include "Vendor.h"
 
 #include "PlayingAnimationInfo.h"
 

--- a/qge/SpriteSheet.cpp
+++ b/qge/SpriteSheet.cpp
@@ -1,8 +1,5 @@
 #include "SpriteSheet.h"
 
-#include <QPixmap>
-#include <QRect>
-
 #include "Node.h"
 
 using namespace qge;

--- a/qge/SpriteSheet.h
+++ b/qge/SpriteSheet.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <QPixmap>
+#include "Vendor.h"
 
 #include "Grid.h"
 

--- a/qge/TerrainLayer.cpp
+++ b/qge/TerrainLayer.cpp
@@ -1,11 +1,5 @@
 #include "TerrainLayer.h"
 
-#include <QRectF>
-#include <QPixmap>
-#include <QGraphicsScene>
-#include <QGraphicsOpacityEffect>
-#include <QGraphicsPixmapItem>
-
 #include "Node.h"
 
 using namespace qge;

--- a/qge/TerrainLayer.h
+++ b/qge/TerrainLayer.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include <QPixmap>
-#include <QPointF>
-#include <QGraphicsPixmapItem>
+#include "Vendor.h"
 
 #include "Node.h"
 #include "Grid.h"

--- a/qge/TopDownSprite.cpp
+++ b/qge/TopDownSprite.cpp
@@ -1,7 +1,5 @@
 #include "TopDownSprite.h"
 
-#include <cassert>
-
 #include "Sprite.h"
 #include "SpriteSheet.h"
 #include "Node.h"

--- a/qge/TopDownSprite.h
+++ b/qge/TopDownSprite.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <string>
+#include "Vendor.h"
 
 #include "EntitySprite.h"
 

--- a/qge/Tree.cpp
+++ b/qge/Tree.cpp
@@ -1,7 +1,5 @@
 #include "Tree.h"
 
-#include <cassert>
-
 using namespace qge;
 
 /// Constructs a Tree with just a root Node.

--- a/qge/Tree.h
+++ b/qge/Tree.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <vector>
+#include "Vendor.h"
 
 #include "Graph.h"
 #include "Node.h"

--- a/qge/Utilities.cpp
+++ b/qge/Utilities.cpp
@@ -5,11 +5,6 @@
 
 #include "Utilities.h"
 
-#include <stdlib.h>
-#include <time.h>
-#include <cassert>
-#include <QtMath>
-
 #include "Map.h"
 #include "RandomImageEntity.h"
 #include "PathingMap.h"

--- a/qge/Utilities.h
+++ b/qge/Utilities.h
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <QtGlobal>
-#include <vector>
+#include "Vendor.h"
 
 class QPointF;
 

--- a/qge/Vendor.h
+++ b/qge/Vendor.h
@@ -1,0 +1,60 @@
+#ifndef VENDOR_H
+#define VENDOR_H
+
+// Standard libraries
+#include <cstdlib>
+#include <time.h>
+#include <ctime>
+#include <stdexcept>
+#include <set>
+#include <cmath>
+#include <algorithm>
+#include <cassert>
+#include <typeinfo>
+#include <typeindex>
+#include <utility>
+#include <vector>
+#include <unordered_set>
+#include <unordered_map>
+#include <string>
+#include <memory>
+#include <iterator>
+
+// QT Related
+#include <QDebug>
+#include <QPointer>
+#include <QObject>
+#include <QSize>
+#include <QSizeF>
+#include <QImage>
+#include <QGraphicsView>
+#include <QGraphicsScene>
+#include <QGraphicsItem>
+#include <QGraphicsRectItem>
+#include <QGraphicsTextItem>
+#include <QGraphicsPixmapItem>
+#include <QGraphicsSceneMouseEvent>
+#include <QGraphicsSimpleTextItem>
+#include <QGraphicsOpacityEffect>
+#include <QThread>
+#include <QColor>
+#include <QPixmap>
+#include <QPointF>
+#include <QPoint>
+#include <QTimer>
+#include <QGraphicsPolygonItem>
+#include <QLineF>
+#include <QRectF>
+#include <QPolygonF>
+#include <QMetaType>
+#include <QMediaPlayer>
+#include <QtGlobal>
+#include <QBrush>
+#include <QFont>
+#include <QtMath>
+#include <QMouseEvent>
+#include <QPen>
+#include <QLine>
+
+
+#endif // VENDOR_H

--- a/qge/WeatherEffect.cpp
+++ b/qge/WeatherEffect.cpp
@@ -1,7 +1,5 @@
 #include "WeatherEffect.h"
 
-#include <cassert>
-
 #include "Map.h"
 
 using namespace qge;

--- a/qge/WeatherEffect.h
+++ b/qge/WeatherEffect.h
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <QObject>
-#include <QPointer>
+#include "Vendor.h"
 
 #include "Map.h"
 

--- a/qge/qge.pri
+++ b/qge/qge.pri
@@ -239,3 +239,6 @@ HEADERS  += \ # this is just so we can line up all our headers nicely
 
 RESOURCES += \ # this is our resource file (specifies resources (images, audio files, etc) we want embedded in our executable)
     $$PWD/res.qrc
+
+PRECOMPILED_HEADER += \
+    $$PWD/Vendor.h


### PR DESCRIPTION
In this pull request the build time has been optimized.
built time is now faster thanks to pre-compiled headers of libraries (headers which will never change).

The only trade-off is file size, but if needed we can make separated pre-compiled headers for specific use-cases.

I've tested some of the examples and they all seems to work. but please test it yourself too before merge :)

Before:
![before_build_time](https://user-images.githubusercontent.com/16985712/50048512-e9f63300-00ce-11e9-98d8-11c10aea0e1b.jpg)
![before_file_size](https://user-images.githubusercontent.com/16985712/50048513-ec588d00-00ce-11e9-98d5-0583309397a3.jpg)

After:
![after_build_time](https://user-images.githubusercontent.com/16985712/50048515-f37f9b00-00ce-11e9-9f5b-750a8b618423.jpg)
![after_file_size](https://user-images.githubusercontent.com/16985712/50048516-f5495e80-00ce-11e9-85b6-a19b1a13d16f.jpg)

As reference: [Pre-Compiled Headers](https://en.wikipedia.org/wiki/Precompiled_header)